### PR TITLE
Fix rotations on bottom side, fix last item in BOM

### DIFF
--- a/ulps/jlcpcb_smta_exporter.ulp
+++ b/ulps/jlcpcb_smta_exporter.ulp
@@ -126,6 +126,9 @@ if (board) board(B) {
                 }
             }
         }
+        if (current_value != "") {
+          printf("%s,%s,%s,%s\n", current_value, designators, current_footprint, current_lscpart);
+        }
     }
 
   dlgMessageBox("BOM and CPL files have been exported to: " + output_dir, "OK");

--- a/ulps/jlcpcb_smta_exporter.ulp
+++ b/ulps/jlcpcb_smta_exporter.ulp
@@ -73,11 +73,17 @@ if (board) board(B) {
 
         for (int i = 0 ; i < element_count ; ++i) {
             UL_ELEMENT E = selected_elements[i];
-
+            int angle = E.angle;
+            if (layer_name_map[layer_choice] == "Bottom") {
+              angle = (360 - angle);
+              angle = angle + 180;
+              angle = angle % 360;
+            }
+            real ang = angle;
             printf("%s,%5.2f,%5.2f,%s,%.1f\n",
                 E.name, u2mm(E.x), u2mm(E.y),
                 layer_name_map[layer_choice],
-                E.angle);
+                ang);
         }
     }
 


### PR DESCRIPTION
I observed that the rotation of components on the bottom side is mirrored, i do not know whether this is a problem with JLC or with Eagle, but i fixed it in this ULP.
I also fixed a bug where the last item of the BOM was missing.