### PR TITLE
Convert commas to spaces to prevent CSV misalignment

### DIFF
--- a/ulps/jlcpcb_smta_exporter.ulp
+++ b/ulps/jlcpcb_smta_exporter.ulp
@@ -120,6 +120,12 @@ if (board) board(B) {
             current_footprint = E.footprint.name;
             current_lscpart = "";
 
+            E.attributes(A) {
+                if (A.name == "LCSC_PART") {
+                    current_lscpart = A.value;
+                }
+            }
+
             while (strstr(current_value, ",") >= 0) {  // convert commas to spaces
                 string substitution_string = " ";
                 sprintf(current_value, "%s%s%s", strsub(current_value, 0, strstr(current_value, ",")), substitution_string, strsub(current_value, strstr(current_value, ",")+1));
@@ -133,12 +139,6 @@ if (board) board(B) {
             while (strstr(current_lscpart, ",") >= 0) {  // convert commas to spaces
                 string substitution_string = " ";
                 sprintf(current_lscpart, "%s%s%s", strsub(current_lscpart, 0, strstr(current_lscpart, ",")), substitution_string, strsub(current_lscpart, strstr(current_lscpart, ",")+1));
-            }
-
-            E.attributes(A) {
-                if (A.name == "LCSC_PART") {
-                    current_lscpart = A.value;
-                }
             }
         }
         if (current_value != "") {

--- a/ulps/jlcpcb_smta_exporter.ulp
+++ b/ulps/jlcpcb_smta_exporter.ulp
@@ -31,6 +31,16 @@ int layer_id_map[] = { 1, 16 };
 UL_ELEMENT selected_elements[];
 string layer_name_map[] = { "Top", "Bottom" };
 
+string replace_commas(string s)
+{
+    while (strstr(s, ",") >= 0) {  // convert commas to spaces
+        string substitution_string = " ";
+        sprintf(s, "%s%s%s", strsub(s, 0, strstr(s, ",")), substitution_string, strsub(s, strstr(s, ",")+1));
+    }
+
+    return s;
+}
+
 if (board) board(B) {
 
     string txt;
@@ -116,29 +126,14 @@ if (board) board(B) {
                 designators += " ";
             }
             designators += E.name;
-            current_value = E.value;
-            current_footprint = E.footprint.name;
+            current_value = replace_commas(E.value);
+            current_footprint = replace_commas(E.footprint.name);
             current_lscpart = "";
 
             E.attributes(A) {
                 if (A.name == "LCSC_PART") {
-                    current_lscpart = A.value;
+                    current_lscpart = replace_commas(A.value);
                 }
-            }
-
-            while (strstr(current_value, ",") >= 0) {  // convert commas to spaces
-                string substitution_string = " ";
-                sprintf(current_value, "%s%s%s", strsub(current_value, 0, strstr(current_value, ",")), substitution_string, strsub(current_value, strstr(current_value, ",")+1));
-            }
-
-            while (strstr(current_footprint, ",") >= 0) {  // convert commas to spaces
-                string substitution_string = " ";
-                sprintf(current_footprint, "%s%s%s", strsub(current_footprint, 0, strstr(current_footprint, ",")), substitution_string, strsub(current_footprint, strstr(current_footprint, ",")+1));
-            }
-
-            while (strstr(current_lscpart, ",") >= 0) {  // convert commas to spaces
-                string substitution_string = " ";
-                sprintf(current_lscpart, "%s%s%s", strsub(current_lscpart, 0, strstr(current_lscpart, ",")), substitution_string, strsub(current_lscpart, strstr(current_lscpart, ",")+1));
             }
         }
         if (current_value != "") {

--- a/ulps/jlcpcb_smta_exporter.ulp
+++ b/ulps/jlcpcb_smta_exporter.ulp
@@ -120,6 +120,21 @@ if (board) board(B) {
             current_footprint = E.footprint.name;
             current_lscpart = "";
 
+            while (strstr(current_value, ",") >= 0) {  // convert commas to spaces
+                string substitution_string = " ";
+                sprintf(current_value, "%s%s%s", strsub(current_value, 0, strstr(current_value, ",")), substitution_string, strsub(current_value, strstr(current_value, ",")+1));
+            }
+
+            while (strstr(current_footprint, ",") >= 0) {  // convert commas to spaces
+                string substitution_string = " ";
+                sprintf(current_footprint, "%s%s%s", strsub(current_footprint, 0, strstr(current_footprint, ",")), substitution_string, strsub(current_footprint, strstr(current_footprint, ",")+1));
+            }
+
+            while (strstr(current_lscpart, ",") >= 0) {  // convert commas to spaces
+                string substitution_string = " ";
+                sprintf(current_lscpart, "%s%s%s", strsub(current_lscpart, 0, strstr(current_lscpart, ",")), substitution_string, strsub(current_lscpart, strstr(current_lscpart, ",")+1));
+            }
+
             E.attributes(A) {
                 if (A.name == "LCSC_PART") {
                     current_lscpart = A.value;


### PR DESCRIPTION
I ran into trouble where the CSV file gets misaligned if there are commas in component values.
Though it's much more common to use spaces rather than commas, I just wanted to make the ULP a bit more fail-safe.
The ULP now converts commas to spaces in value, footprint fields, and LCSC_PART attributes.