### PR TITLE
feat: attribute JLC_ROTATION is added to the angle field in the CPL file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,6 @@ Observe the following:
 4. the two files will be named ```<boardname>_<side>_bom.csv``` and ```<boardname>_<side>_cpl.csv```
 5. components rotations are sketchy and must be visually checked on the online gerber viewer once uploaded the files
 
-The ULP can extract LCSC part ordering numbers from the packages attributes. The attribute must be named _LCSC_PART_ 
-and it should contain the order code found in the parts library https://jlcpcb.com/client/index.html#/parts (eg: C25804).
+The ULP can extract LCSC part ordering numbers from the packages attributes. The attribute must be named _LCSC_PART_ or _LCSC_ and it should contain the order code found in the parts library https://jlcpcb.com/client/index.html#/parts (eg: C25804).
+
+The ULP can also manually rotate the angle in the CPL output file. The attribute must be named _JLC_ROTATION_. For example, if a part's angle in set to 90 and it's attribute _JLC_ROTATION_ is set to 180, the angle in the final CPL file will be set to 270.

--- a/ulps/jlcpcb_smta_exporter.ulp
+++ b/ulps/jlcpcb_smta_exporter.ulp
@@ -111,14 +111,14 @@ if (board) board(B) {
 
         string current_value = "";
         string current_footprint = "";
-        string current_lscpart = "";
+        string current_lcscpart = "";
         string designators = "";
 
         for (i = 0 ; i < element_count ; ++i) {
             UL_ELEMENT E = selected_elements[indexes[i]];
 
             if (current_value != "" && (E.value != current_value || E.footprint.name != current_footprint)) {
-                printf("%s,%s,%s,%s\n", current_value, designators, current_footprint, current_lscpart);
+                printf("%s,%s,%s,%s\n", current_value, designators, current_footprint, current_lcscpart);
                 designators = "";
             }
 
@@ -128,16 +128,16 @@ if (board) board(B) {
             designators += E.name;
             current_value = replace_commas(E.value);
             current_footprint = replace_commas(E.footprint.name);
-            current_lscpart = "";
+            current_lcscpart = "";
 
             E.attributes(A) {
-                if (A.name == "LCSC_PART") {
-                    current_lscpart = replace_commas(A.value);
+                if (A.name == "LCSC_PART" || A.name == "LCSC") {
+                    current_lcscpart = replace_commas(A.value);
                 }
             }
         }
         if (current_value != "") {
-          printf("%s,%s,%s,%s\n", current_value, designators, current_footprint, current_lscpart);
+          printf("%s,%s,%s,%s\n", current_value, designators, current_footprint, current_lcscpart);
         }
     }
 

--- a/ulps/jlcpcb_smta_exporter.ulp
+++ b/ulps/jlcpcb_smta_exporter.ulp
@@ -84,6 +84,17 @@ if (board) board(B) {
         for (int i = 0 ; i < element_count ; ++i) {
             UL_ELEMENT E = selected_elements[i];
             int angle = E.angle;
+
+            E.attributes(A) {  // manually rotate the part
+                if (A.name == "JLC_ROTATION") {
+                    angle = angle + strtol(A.value);
+
+                    while(angle>360){
+                        angle = angle - 360;
+                    }
+                }
+            }
+
             if (layer_name_map[layer_choice] == "Bottom") {
               angle = (360 - angle);
               angle = angle + 180;


### PR DESCRIPTION
Since JLCPCB's pin 1 angle position isn't very consistent, I thought it would be useful if the script automatically modifies the angle within a project.
If a part has an attribute named "JLC_ROTATION", the angle in the CPL file will be rotated accordingly.

I also added "LCSC" as well as "LCSC_PART" for extracting the LCSC part number, and The README file has also been updated.

Feel free to modify the files before merging.