### PR TITLE
Removed Top/Bottom side assembly selection in favor of automatic dual…

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ SMT assembly service.
 Observe the following:
 
 1. it must be executed from the board editor
-2. it asks for the layer to process (either top or bottom), this must be consistent with the ordering process
-3. it asks for a directory where to export the two files
-4. the two files will be named ```<boardname>_<side>_bom.csv``` and ```<boardname>_<side>_cpl.csv```
-5. components rotations are sketchy and must be visually checked on the online gerber viewer once uploaded the files
+2. it asks for a directory where to export the two files
+3. the two resulting files will be named ```<boardname>_bom.csv``` and ```<boardname>_cpl.csv```
+4. components rotations are sketchy and must be visually checked on the online gerber viewer once uploaded the files
 
 The ULP can extract LCSC part ordering numbers from the packages attributes. The attribute must be named _LCSC_PART_ or _LCSC_ and it should contain the order code found in the parts library https://jlcpcb.com/client/index.html#/parts (eg: C25804).
 
 The ULP can also manually rotate the angle in the CPL output file. The attribute must be named _JLC_ROTATION_. For example, if a part's angle in set to 90 and it's attribute _JLC_ROTATION_ is set to 180, the angle in the final CPL file will be set to 270.
+
+Top and/or bottom assembly can be chosen directly during the ordering process, JLCPCB will use the CPL file to determine which side the
+designator has been placed on.

--- a/ulps/jlcpcb_smta_exporter.ulp
+++ b/ulps/jlcpcb_smta_exporter.ulp
@@ -19,7 +19,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #usage "<b>JLCPCB BOM/CPL files generator</b>\n"
        "<p>"
-       "Generates BOM and CPL files for JLCPCB SMT/TH assembly service"
+       "Generates BOM and CPL files for JLCPCB SMT/TH dual side assembly service"
        "https://jlcpcb.com/smt-assembly"
        "<p>"
        "Run the ULP from the board editor"
@@ -95,19 +95,6 @@ string get_lcsc_part(UL_ELEMENT E)
 
 if (board) board(B) {
 
-    string txt;
-    int layer_choice = 0;
-    int export_th = 1;
-
-    dlgDialog("Export selection") {
-        dlgGroup("Export layer") {
-            dlgRadioButton("&Top", layer_choice);
-            dlgRadioButton("&Bottom", layer_choice);
-        }
-        dlgCheckBox("&Export also TH components", export_th);
-        dlgPushButton("OK") dlgAccept();
-    };
-
     string output_dir = dlgDirectory("Export files to", filedir(B.name));
 
     if (output_dir == "") {
@@ -119,17 +106,15 @@ if (board) board(B) {
     // Gather the components that will appear in BOM/CPL
     B.elements(E) if (E.populate) {
         E.package.contacts(C) {
-            if ((C.smd && C.smd.layer == layer_id_map[layer_choice])
-                    || (!C.smd && export_th && E.mirror == layer_choice)) {
+            if (C.smd || C.pad) {
                 selected_elements[element_count++] = E;
                 break;
             }
         }
     }
 
-    string base_path = (output_dir + "/" +
-        strsub(filename(B.name), 0, strlen(filename(B.name)) - 4) +
-        "_" + strlwr(layer_name_map[layer_choice]));
+    string base_path = (output_dir + "/" + 
+        strsub(filename(B.name), 0, strlen(filename(B.name)) - 4));
 
     string cpl_filename = base_path + "_cpl.csv";
     string bom_filename = base_path + "_bom.csv";
@@ -141,6 +126,11 @@ if (board) board(B) {
             UL_ELEMENT E = selected_elements[i];
             real angle = E.angle;
 
+            string layer = "Top";
+            if (E.mirror) {
+                layer = "Bottom";
+            }
+
             E.attributes(A) {  // manually rotate the part
                 if (A.name == "JLC_ROTATION") {
                     // Note: supporting only integer offsets
@@ -148,13 +138,13 @@ if (board) board(B) {
                 }
             }
 
-            if (layer_name_map[layer_choice] == "Bottom") {
+            if (layer == "Bottom") {
                 angle += 180;
             }
 
             printf("%s,%5.2f,%5.2f,%s,%.1f\n",
                 E.name, u2mm(E.x), u2mm(E.y),
-                layer_name_map[layer_choice],
+                layer,
                 angle_mod(angle));
         }
     }


### PR DESCRIPTION
I removed the side selection dialog box. JLCPCB allows the selection of the assembled layer, so I prefer to have all my components in the BOM & CPL. This altered version of your code places all components in the generated BOM & CPL.